### PR TITLE
fix(daemon): split overnight curfew windows across midnight

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -79,9 +79,11 @@ is actually allowed inside the curfew window and denied outside it. The test PAM
 service layers `pam_time.so` over a `pam_permit.so` fallback, mirroring how
 pam_time sits on a real account stack (a no-match must not deny).
 
-`test_curfew_enforcement.py::test_overnight_curfew_behaviour` characterises a
-latent bug: overnight windows like `22:00-06:00` are emitted as the start>end
-range `Wk2200-0600`, which pam_time does not treat as wrapping past midnight.
+`test_curfew_enforcement.py::test_overnight_curfew_enforced` covers overnight
+windows like `22:00-06:00`. These used to be emitted as the start>end range
+`Wk2200-0600`, which pam_time does not treat as wrapping past midnight; the test
+proves the (now fixed) splitting into `Wk2200-2400 | Wk0000-0600` is enforced on
+both sides of midnight.
 
 ## Not yet implemented / external
 
@@ -98,6 +100,11 @@ range `Wk2200-0600`, which pam_time does not treat as wrapping past midnight.
 
 ## Reliability fixes surfaced while building this
 
+- `user_manager._generate_rules()` emitted overnight curfews (e.g. `22:00-06:00`)
+  as the start>end range `Wk2200-0600`, which `pam_time.so` does not wrap past
+  midnight, so the curfew silently failed to restrict logins. It now splits such
+  windows into `Wk2200-2400 | Wk0000-0600` (matching `_is_user_in_curfew`'s
+  existing overnight handling); the L3 PAM test enforces both halves for real.
 - `storage.py` resolved the Alembic `script_location` relative to the process
   CWD, so DB migrations failed whenever the daemon/tests were launched from any
   directory other than `guardian_daemon/`. Now resolved against the daemon dir.

--- a/guardian_daemon/guardian_daemon/user_manager.py
+++ b/guardian_daemon/guardian_daemon/user_manager.py
@@ -811,7 +811,15 @@ class UserManager:
                         start, end = time_range.split("-")
                         start = start.replace(":", "")
                         end = end.replace(":", "")
-                        time_specs.append(f"{day_code}{start}-{end}")
+                        if int(start) < int(end):
+                            time_specs.append(f"{day_code}{start}-{end}")
+                        else:
+                            # Overnight window (e.g. 22:00-06:00): pam_time does
+                            # not treat a start>end range as wrapping past
+                            # midnight, so split it into two ranges that meet at
+                            # midnight (matching _is_user_in_curfew's handling).
+                            time_specs.append(f"{day_code}{start}-2400")
+                            time_specs.append(f"{day_code}0000-{end}")
 
                 if time_specs:
                     # Apply the combined rule to all services and ttys for the user.

--- a/tests/pam/test_curfew_enforcement.py
+++ b/tests/pam/test_curfew_enforcement.py
@@ -74,24 +74,32 @@ def test_non_kid_user_always_allowed(make_user_manager, pam_curfew):
     ), f"expected non-managed user always allowed, got: {proc.stderr or proc.stdout}"
 
 
-def test_overnight_curfew_behaviour(make_user_manager, pam_curfew):
-    """Characterisation test for the overnight-window bug.
+def test_overnight_curfew_enforced(make_user_manager, pam_curfew):
+    """Overnight window (allow 22:00-06:00, deny during the day) is enforced
+    across midnight.
 
-    Intended policy: allow 22:00-06:00, deny during the day. The generated
-    'Wk2200-0600' is a start>end range. We assert what pam_time ACTUALLY does at
-    14:00 (clearly outside the intended overnight window) so the behaviour is
-    pinned; when _generate_rules() is fixed to split overnight windows, update
-    this expectation.
+    _generate_rules() splits the wrapping window into Wk2200-2400 | Wk0000-0600
+    so pam_time evaluates both the pre- and post-midnight halves. Tested on a
+    Monday, which is a weekday on both sides of midnight.
     """
     rules = make_user_manager(
         users={"kid1": {"curfew": {"weekdays": "22:00-06:00"}}}
     )._generate_rules()
-    allowed_midday, proc = pam_curfew("kid1", rules, f"{MONDAY} 14:00:00")
-    # Document the real outcome rather than assuming; the value here reflects how
-    # pam_time treats the inverted range and is the signal that the curfew is not
-    # behaving as a parent would expect for overnight windows.
-    assert allowed_midday in (True, False)
-    print(
-        f"[overnight-curfew] Wk2200-0600 at Mon 14:00 -> "
-        f"{'ALLOWED' if allowed_midday else 'DENIED'} (intended: DENIED)"
-    )
+
+    # Midday is outside the overnight window -> login denied.
+    allowed_midday, _ = pam_curfew("kid1", rules, f"{MONDAY} 14:00:00")
+    assert (
+        not allowed_midday
+    ), "expected login denied at Mon 14:00 (outside 22:00-06:00)"
+
+    # Late evening, before midnight, is inside the window -> login allowed.
+    allowed_evening, proc = pam_curfew("kid1", rules, f"{MONDAY} 23:00:00")
+    assert (
+        allowed_evening
+    ), f"expected login allowed at Mon 23:00, got: {proc.stderr or proc.stdout}"
+
+    # Early morning, after midnight, is inside the window -> login allowed.
+    allowed_morning, proc = pam_curfew("kid1", rules, f"{MONDAY} 02:00:00")
+    assert (
+        allowed_morning
+    ), f"expected login allowed at Mon 02:00, got: {proc.stderr or proc.stdout}"

--- a/tests/pam/test_rule_generation.py
+++ b/tests/pam/test_rule_generation.py
@@ -60,17 +60,19 @@ def test_multiple_kids_each_get_a_rule(make_user_manager):
     assert "Wk0730-1930" in _kid_rule(rules, "kid2").split(";")[-1].split("|")
 
 
-def test_overnight_curfew_generates_inverted_range(make_user_manager):
-    """Documents a latent bug: an overnight window (22:00-06:00) is emitted as
-    'Wk2200-0600', a start>end range that pam_time does not interpret as
-    wrapping past midnight. _generate_rules() (unlike _is_user_in_curfew) has no
-    overnight handling. The PAM-level consequence is asserted in
-    test_curfew_enforcement.py::test_overnight_curfew_behaviour.
+def test_overnight_curfew_splits_across_midnight(make_user_manager):
+    """An overnight window (22:00-06:00) wraps past midnight, which pam_time does
+    not handle for a single start>end range. _generate_rules() therefore splits
+    it into two ranges meeting at midnight (Wk2200-2400 | Wk0000-0600) so
+    pam_time enforces both halves. The PAM-level behaviour is asserted in
+    test_curfew_enforcement.py::test_overnight_curfew_enforced.
     """
     um = make_user_manager(
         users={"kid1": {"curfew": {"weekdays": "22:00-06:00"}}},
         defaults=NO_DEFAULT_CURFEW,
     )
-    assert "Wk2200-0600" in _kid_rule(um._generate_rules(), "kid1").split(";")[
-        -1
-    ].split("|")
+    parts = _kid_rule(um._generate_rules(), "kid1").split(";")[-1].split("|")
+    assert "Wk2200-2400" in parts
+    assert "Wk0000-0600" in parts
+    # The naive (non-wrapping) start>end range must not be emitted.
+    assert "Wk2200-0600" not in parts


### PR DESCRIPTION
## Problem

`UserManager._generate_rules()` emitted an overnight curfew window such as
`22:00–06:00` as the start>end range `Wk2200-0600`. `pam_time.so` does **not**
treat a start>end range as wrapping past midnight, so the rule silently failed
to restrict logins — the curfew did not actually enforce anything for overnight
windows.

This was the latent bug the new L3 PAM test layer (merged in #3) was written to
characterise: `_is_user_in_curfew()` already handled overnight windows, but the
rule generator that feeds `pam_time.so` did not, so the two code paths
disagreed.

## Fix

When a window's start is later than its end, split it into two ranges that meet
at midnight, matching the existing overnight handling in `_is_user_in_curfew()`:

```
Wk2200-0600   →   Wk2200-2400 | Wk0000-0600
```

## Verification (real, not mocked)

- **L3 PAM** (`tests/pam`, 11 passed): `test_overnight_curfew_enforced` drives
  the real `pam_time.so` via `pamtester` + `faketime` and asserts login is
  **denied** at Mon 14:00 (outside the window) and **allowed** at Mon 23:00 and
  Mon 02:00 (inside, on both sides of midnight). The previous characterisation
  test is now a genuine regression test.
- **L1** guardian_daemon unit tests: 262 passed (no regression).
- **L0** lint: ruff / black / isort clean.

## Changes

- `guardian_daemon/guardian_daemon/user_manager.py` — split overnight windows in `_generate_rules()`.
- `tests/pam/test_rule_generation.py` — `test_overnight_curfew_generates_inverted_range` → `test_overnight_curfew_splits_across_midnight` (asserts the two halves, excludes the old `Wk2200-0600`).
- `tests/pam/test_curfew_enforcement.py` — `test_overnight_curfew_behaviour` → `test_overnight_curfew_enforced` (asserts real allow/deny across midnight).
- `TESTING.md` — documents the fix under reliability fixes.

https://claude.ai/code/session_01GsUUGN8yWqX8tPkHoQQgu2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsUUGN8yWqX8tPkHoQQgu2)_