### PR TITLE
fix(daemon): align the secondary curfew checks with PAM enforcement

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -116,6 +116,15 @@ both sides of midnight.
   All three now read the canonical schema with overnight-aware windows, and
   `_is_user_in_curfew` correctly reports the blocked period (the complement of
   the allowed login window) instead of being silently inverted.
+- The same curfew checks also disagreed with PAM on *which users* have a curfew:
+  `get_user_curfew()` read only the explicit per-user config, while
+  `_generate_rules()` falls back to (and per-day merges) the **default** curfew.
+  A user relying on the default curfew was therefore restricted by `pam_time` but
+  reported as "no curfew" by `check_curfew()`/`_is_user_in_curfew()` (which also
+  short-circuited on the explicit-only `has_curfew()`). Both now resolve the
+  *effective* curfew through a single shared `policy.get_effective_curfew()` --
+  the very helper `_generate_rules()` uses -- so the Python checks and the PAM
+  rules can no longer drift.
 - `storage.py` resolved the Alembic `script_location` relative to the process
   CWD, so DB migrations failed whenever the daemon/tests were launched from any
   directory other than `guardian_daemon/`. Now resolved against the daemon dir.

--- a/TESTING.md
+++ b/TESTING.md
@@ -105,6 +105,17 @@ both sides of midnight.
   midnight, so the curfew silently failed to restrict logins. It now splits such
   windows into `Wk2200-2400 | Wk0000-0600` (matching `_is_user_in_curfew`'s
   existing overnight handling); the L3 PAM test enforces both halves for real.
+- `policy.get_user_curfew()` (and its consumers `sessions.check_curfew()` and
+  `user_manager._is_user_in_curfew()`) read a *different* curfew schema
+  (`weekday`/`weekend` -> `{start, end}`) than the rest of the system produces -
+  the config, IPC write-validation, CLI and PAM enforcement all use
+  `weekdays`/`saturday`/`sunday` -> `"HH:MM-HH:MM"`. On any real config the
+  reader therefore returned `None`, making both consumers inert (always-allow /
+  always-false), and the daemon's `in_curfew=` log was meaningless. The unit
+  tests only stayed green because the per-user fixtures used the phantom schema.
+  All three now read the canonical schema with overnight-aware windows, and
+  `_is_user_in_curfew` correctly reports the blocked period (the complement of
+  the allowed login window) instead of being silently inverted.
 - `storage.py` resolved the Alembic `script_location` relative to the process
   CWD, so DB migrations failed whenever the daemon/tests were launched from any
   directory other than `guardian_daemon/`. Now resolved against the daemon dir.

--- a/guardian_daemon/guardian_daemon/policy.py
+++ b/guardian_daemon/guardian_daemon/policy.py
@@ -3,6 +3,7 @@ Policy loader for guardian-daemon.
 Loads and validates settings from a YAML configuration file.
 """
 
+import datetime
 from typing import Any, Dict, Optional
 
 from guardian_daemon.config import Config
@@ -10,6 +11,40 @@ from guardian_daemon.logging import get_logger
 from guardian_daemon.storage import Storage
 
 logger = get_logger("Policy")
+
+# Map datetime.weekday() (Monday=0 .. Sunday=6) to the curfew keys to try, in
+# priority order. "all" applies to every day and is the fallback used when no
+# day-specific window is configured.
+_CURFEW_DAY_KEYS: dict[int, tuple[str, ...]] = {
+    0: ("weekdays", "all"),
+    1: ("weekdays", "all"),
+    2: ("weekdays", "all"),
+    3: ("weekdays", "all"),
+    4: ("weekdays", "all"),
+    5: ("saturday", "all"),
+    6: ("sunday", "all"),
+}
+
+
+def parse_hhmm(value: str) -> datetime.time:
+    """Parse an ``"HH:MM"`` string into a :class:`datetime.time`."""
+    hour, minute = map(int, value.split(":"))
+    return datetime.time(hour, minute)
+
+
+def is_within_curfew_window(
+    current: datetime.time, start: datetime.time, end: datetime.time
+) -> bool:
+    """Return True if ``current`` falls inside the allowed login window.
+
+    Curfew windows describe the time during which login is *allowed*. The window
+    is half-open ``[start, end)``. A window whose start is later than its end
+    (e.g. ``22:00``-``06:00``) wraps past midnight, mirroring the
+    split-at-midnight rules emitted for ``pam_time.so``.
+    """
+    if start > end:
+        return current >= start or current < end
+    return start <= current < end
 
 
 class Policy:
@@ -94,14 +129,35 @@ class Policy:
 
         return daily, weekly
 
-    def get_user_curfew(
-        self, username: str, is_weekend: bool
-    ) -> Optional[dict[str, str]]:
-        """Get curfew settings for a user."""
+    def get_user_curfew(self, username: str, weekday: int) -> Optional[dict[str, str]]:
+        """Return the allowed-login window for ``username`` on a given weekday.
+
+        Args:
+            username: The user to look up.
+            weekday: Day of week as :meth:`datetime.date.weekday`
+                (Monday=0 .. Sunday=6).
+
+        Returns:
+            ``{"start": "HH:MM", "end": "HH:MM"}`` describing the window during
+            which login is allowed, or ``None`` if the user has no curfew for
+            that day. Curfew is stored as per-day ``"HH:MM-HH:MM"`` ranges keyed
+            by ``weekdays``/``saturday``/``sunday``/``all``.
+        """
         user_settings = self.data.get("users", {}).get(username, {})
         curfew = user_settings.get("curfew", {})
-        period = "weekend" if is_weekend else "weekday"
-        return curfew.get(period)
+        if not isinstance(curfew, dict):
+            return None
+
+        window = None
+        for key in _CURFEW_DAY_KEYS.get(weekday, ("all",)):
+            if curfew.get(key):
+                window = curfew[key]
+                break
+
+        if not isinstance(window, str) or "-" not in window:
+            return None
+        start, end = window.split("-", 1)
+        return {"start": start.strip(), "end": end.strip()}
 
     def get_monitored_users(self) -> list[str]:
         """Get list of all monitored users (excluding those with monitored: False)."""

--- a/guardian_daemon/guardian_daemon/policy.py
+++ b/guardian_daemon/guardian_daemon/policy.py
@@ -129,8 +129,30 @@ class Policy:
 
         return daily, weekly
 
+    def get_effective_curfew(self, username: str) -> Optional[dict]:
+        """Return the effective curfew for a user as a per-day mapping.
+
+        Merges the user's own curfew over the configured defaults -- the same
+        resolution :meth:`UserManager._generate_rules` uses to emit ``pam_time``
+        rules -- so the Python-level curfew checks agree with what PAM actually
+        enforces. Returns ``None`` when neither the user nor the defaults define
+        a curfew.
+        """
+        user_policy = self.get_user_policy(username)
+        if not user_policy:
+            return None
+        curfew = user_policy.get("curfew")
+        if curfew is None:
+            curfew = self.get_default("curfew")
+        return curfew if isinstance(curfew, dict) and curfew else None
+
     def get_user_curfew(self, username: str, weekday: int) -> Optional[dict[str, str]]:
         """Return the allowed-login window for ``username`` on a given weekday.
+
+        The window reflects the *effective* curfew (the user's own settings
+        merged over the configured defaults), i.e. the same windows
+        :meth:`UserManager._generate_rules` emits, so a user that relies on the
+        default curfew is reported as restricted here too.
 
         Args:
             username: The user to look up.
@@ -139,13 +161,12 @@ class Policy:
 
         Returns:
             ``{"start": "HH:MM", "end": "HH:MM"}`` describing the window during
-            which login is allowed, or ``None`` if the user has no curfew for
-            that day. Curfew is stored as per-day ``"HH:MM-HH:MM"`` ranges keyed
-            by ``weekdays``/``saturday``/``sunday``/``all``.
+            which login is allowed, or ``None`` if no curfew applies that day.
+            Curfew is stored as per-day ``"HH:MM-HH:MM"`` ranges keyed by
+            ``weekdays``/``saturday``/``sunday``/``all``.
         """
-        user_settings = self.data.get("users", {}).get(username, {})
-        curfew = user_settings.get("curfew", {})
-        if not isinstance(curfew, dict):
+        curfew = self.get_effective_curfew(username)
+        if not curfew:
             return None
 
         window = None

--- a/guardian_daemon/guardian_daemon/sessions.py
+++ b/guardian_daemon/guardian_daemon/sessions.py
@@ -783,14 +783,11 @@ class SessionTracker:
         Returns:
             bool: True if allowed, False if curfew is in effect
         """
-        # If no curfew settings, always allow
-        if not self.policy.has_curfew(username):
-            return True
-
-        # Get the allowed-login window for the given day
+        # Get the allowed-login window for the given day (effective curfew =
+        # the user's own settings merged over the defaults).
         curfew = self.policy.get_user_curfew(username, weekday)
         if not curfew:
-            return True  # No curfew for this day type means allowed
+            return True  # No curfew applies on this day -> always allowed
 
         start_time = parse_hhmm(curfew["start"])
         end_time = parse_hhmm(curfew["end"])

--- a/guardian_daemon/guardian_daemon/sessions.py
+++ b/guardian_daemon/guardian_daemon/sessions.py
@@ -16,7 +16,7 @@ from dbus_next.constants import BusType
 from dbus_next.service import ServiceInterface, method
 
 from guardian_daemon.logging import get_logger
-from guardian_daemon.policy import Policy
+from guardian_daemon.policy import Policy, is_within_curfew_window, parse_hhmm
 from guardian_daemon.storage import Storage
 from guardian_daemon.user_manager import UserManager
 
@@ -772,13 +772,13 @@ class SessionTracker:
 
         return True
 
-    async def check_curfew(self, username: str, current_time, is_weekend: bool) -> bool:
+    async def check_curfew(self, username: str, current_time, weekday: int) -> bool:
         """Check if a user is allowed to log in at the current time based on curfew settings.
 
         Args:
             username (str): Username
             current_time: Current time to check (datetime.time)
-            is_weekend (bool): Whether it's a weekend day
+            weekday (int): Day of week as datetime.weekday() (Monday=0 .. Sunday=6)
 
         Returns:
             bool: True if allowed, False if curfew is in effect
@@ -787,21 +787,21 @@ class SessionTracker:
         if not self.policy.has_curfew(username):
             return True
 
-        # Get curfew settings for the given day type
-        curfew = self.policy.get_user_curfew(username, is_weekend)
+        # Get the allowed-login window for the given day
+        curfew = self.policy.get_user_curfew(username, weekday)
         if not curfew:
             return True  # No curfew for this day type means allowed
 
-        # Parse curfew times
-        start_time = datetime.datetime.strptime(curfew["start"], "%H:%M").time()
-        end_time = datetime.datetime.strptime(curfew["end"], "%H:%M").time()
+        start_time = parse_hhmm(curfew["start"])
+        end_time = parse_hhmm(curfew["end"])
 
-        # Check if current time is within allowed hours
-        if start_time <= current_time <= end_time:
+        # The window is the allowed login time; overnight windows wrap midnight.
+        if is_within_curfew_window(current_time, start_time, end_time):
             return True
 
         logger.info(
-            f"Curfew in effect for {username}: current {current_time}, allowed {start_time}-{end_time}"
+            f"Curfew in effect for {username}: current {current_time}, "
+            f"allowed {curfew['start']}-{curfew['end']}"
         )
         return False
 

--- a/guardian_daemon/guardian_daemon/user_manager.py
+++ b/guardian_daemon/guardian_daemon/user_manager.py
@@ -797,8 +797,7 @@ class UserManager:
         }
 
         for username in managed_users:
-            user_policy = self.policy.get_user_policy(username)
-            curfew = user_policy.get("curfew", self.policy.get_default("curfew"))
+            curfew = self.policy.get_effective_curfew(username)
 
             if curfew:
                 # Create a combined day specification for all allowed times.
@@ -1521,13 +1520,10 @@ class UserManager:
         import datetime
 
         try:
-            # Check if user has curfew configured
-            if not self.policy.has_curfew(username):
-                return False
-
             now = datetime.datetime.now()
 
-            # Get the allowed-login window for the current day
+            # Get the allowed-login window for the current day (effective curfew
+            # = the user's own settings merged over the defaults).
             curfew = self.policy.get_user_curfew(username, now.weekday())
             if not curfew:
                 return False

--- a/guardian_daemon/guardian_daemon/user_manager.py
+++ b/guardian_daemon/guardian_daemon/user_manager.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from guardian_daemon.logging import get_logger
-from guardian_daemon.policy import Policy
+from guardian_daemon.policy import Policy, is_within_curfew_window, parse_hhmm
 
 if TYPE_CHECKING:
     from guardian_daemon.sessions import SessionTracker
@@ -1507,13 +1507,16 @@ class UserManager:
 
     def _is_user_in_curfew(self, username: str) -> bool:
         """
-        Check if a user is currently within their curfew window.
+        Check whether a user is currently in their curfew (blocked) period.
+
+        Curfew windows define the times during which login is *allowed*, so a
+        user is "in curfew" when the current time falls *outside* that window.
 
         Args:
             username: The username to check
 
         Returns:
-            bool: True if currently in curfew, False otherwise
+            bool: True if currently blocked by curfew, False otherwise
         """
         import datetime
 
@@ -1523,32 +1526,18 @@ class UserManager:
                 return False
 
             now = datetime.datetime.now()
-            is_weekend = now.weekday() >= 5  # Saturday=5, Sunday=6
 
-            # Get curfew for current day type
-            curfew = self.policy.get_user_curfew(username, is_weekend)
+            # Get the allowed-login window for the current day
+            curfew = self.policy.get_user_curfew(username, now.weekday())
             if not curfew:
                 return False
 
-            start_time = curfew.get("start")
-            end_time = curfew.get("end")
+            start = parse_hhmm(curfew["start"])
+            end = parse_hhmm(curfew["end"])
 
-            if not start_time or not end_time:
-                return False
-
-            # Parse times
-            start_hour, start_min = map(int, start_time.split(":"))
-            end_hour, end_min = map(int, end_time.split(":"))
-
-            current_time = now.time()
-            start = datetime.time(start_hour, start_min)
-            end = datetime.time(end_hour, end_min)
-
-            # Handle overnight curfews (e.g., 22:00-06:00)
-            if start > end:
-                return current_time >= start or current_time < end
-            else:
-                return start <= current_time < end
+            # "In curfew" is the complement of the allowed login window
+            # (overnight windows wrap past midnight).
+            return not is_within_curfew_window(now.time(), start, end)
 
         except Exception as e:
             logger.error(f"Error checking curfew for {username}: {e}")

--- a/guardian_daemon/tests/conftest.py
+++ b/guardian_daemon/tests/conftest.py
@@ -24,8 +24,9 @@ def test_config():
                     "monthly": 2400,  # 40 hours
                 },
                 "curfew": {
-                    "weekday": {"start": "08:00", "end": "20:00"},
-                    "weekend": {"start": "10:00", "end": "22:00"},
+                    "weekdays": "08:00-20:00",
+                    "saturday": "10:00-22:00",
+                    "sunday": "10:00-22:00",
                 },
                 "bonus_pool": 60,  # 1 hour bonus time
                 "grace_period": 15,  # 15 minutes grace period
@@ -33,9 +34,7 @@ def test_config():
             "test_quota_only": {
                 "quota": {"daily": 60, "weekly": 300}  # 1 hour  # 5 hours
             },
-            "test_weekday_curfew": {
-                "curfew": {"weekday": {"start": "09:00", "end": "21:00"}}
-            },
+            "test_weekday_curfew": {"curfew": {"weekdays": "09:00-21:00"}},
             "test_minimal": {"quota": {"daily": 30}},  # Only daily quota, no weekly
             "test_quota_exempt": {"quota_exempt": True},
             "test_unmonitored": {"monitored": False},

--- a/guardian_daemon/tests/test_policy.py
+++ b/guardian_daemon/tests/test_policy.py
@@ -65,17 +65,32 @@ def test_policy_get_user_curfew(test_config):
     assert sunday["start"] == "10:00"
     assert sunday["end"] == "22:00"
 
-    # Test user with only weekday curfew
+    # User overriding only weekdays -> Sat/Sun windows are inherited from the
+    # defaults (mirroring the rules _generate_rules emits via pam_time).
     weekday = policy.get_user_curfew("test_weekday_curfew", 0)
-    assert weekday["start"] == "09:00"
-    assert weekday["end"] == "21:00"
-    # No saturday/sunday window configured -> None on the weekend
-    assert policy.get_user_curfew("test_weekday_curfew", 5) is None
-    assert policy.get_user_curfew("test_weekday_curfew", 6) is None
+    assert weekday == {"start": "09:00", "end": "21:00"}
+    assert policy.get_user_curfew("test_weekday_curfew", 5) == {
+        "start": "10:00",
+        "end": "22:00",
+    }
+    assert policy.get_user_curfew("test_weekday_curfew", 6) == {
+        "start": "10:00",
+        "end": "20:00",
+    }
 
-    # Test user without curfew settings
-    assert policy.get_user_curfew("test_minimal", 0) is None
-    assert policy.get_user_curfew("test_minimal", 5) is None
+    # User with no explicit curfew still inherits the default curfew (PAM
+    # enforces it for them too), so the check must report it.
+    assert policy.get_user_curfew("test_minimal", 0) == {
+        "start": "08:00",
+        "end": "20:00",
+    }
+    assert policy.get_user_curfew("test_minimal", 5) == {
+        "start": "10:00",
+        "end": "22:00",
+    }
+
+    # Unknown user -> no curfew at all.
+    assert policy.get_user_curfew("nonexistent", 0) is None
 
 
 def test_policy_has_quota(test_config):

--- a/guardian_daemon/tests/test_policy.py
+++ b/guardian_daemon/tests/test_policy.py
@@ -52,24 +52,30 @@ def test_policy_get_user_curfew(test_config):
     config, config_path = test_config
     policy = Policy(config_path)
 
-    # Test user with full settings
-    weekday = policy.get_user_curfew("test_full_settings", is_weekend=False)
+    # Test user with full settings (Monday=0, Saturday=5, Sunday=6)
+    weekday = policy.get_user_curfew("test_full_settings", 0)
     assert weekday["start"] == "08:00"
     assert weekday["end"] == "20:00"
 
-    weekend = policy.get_user_curfew("test_full_settings", is_weekend=True)
-    assert weekend["start"] == "10:00"
-    assert weekend["end"] == "22:00"
+    saturday = policy.get_user_curfew("test_full_settings", 5)
+    assert saturday["start"] == "10:00"
+    assert saturday["end"] == "22:00"
+
+    sunday = policy.get_user_curfew("test_full_settings", 6)
+    assert sunday["start"] == "10:00"
+    assert sunday["end"] == "22:00"
 
     # Test user with only weekday curfew
-    weekday = policy.get_user_curfew("test_weekday_curfew", is_weekend=False)
+    weekday = policy.get_user_curfew("test_weekday_curfew", 0)
     assert weekday["start"] == "09:00"
     assert weekday["end"] == "21:00"
-    assert policy.get_user_curfew("test_weekday_curfew", is_weekend=True) is None
+    # No saturday/sunday window configured -> None on the weekend
+    assert policy.get_user_curfew("test_weekday_curfew", 5) is None
+    assert policy.get_user_curfew("test_weekday_curfew", 6) is None
 
     # Test user without curfew settings
-    assert policy.get_user_curfew("test_minimal", is_weekend=False) is None
-    assert policy.get_user_curfew("test_minimal", is_weekend=True) is None
+    assert policy.get_user_curfew("test_minimal", 0) is None
+    assert policy.get_user_curfew("test_minimal", 5) is None
 
 
 def test_policy_has_quota(test_config):

--- a/guardian_daemon/tests/test_policy_extended.py
+++ b/guardian_daemon/tests/test_policy_extended.py
@@ -186,11 +186,11 @@ async def test_policy_get_user_quota_test_quota_only(test_config):
 
 @pytest.mark.asyncio
 async def test_policy_get_user_curfew_weekday(test_config):
-    """Test get_user_curfew for weekday."""
+    """Test get_user_curfew for a weekday."""
     config, config_path = test_config
     policy = Policy(config_path)
 
-    curfew = policy.get_user_curfew("test_full_settings", is_weekend=False)
+    curfew = policy.get_user_curfew("test_full_settings", 0)  # Monday
 
     # Should return a dict with start and end
     assert curfew is not None
@@ -200,11 +200,11 @@ async def test_policy_get_user_curfew_weekday(test_config):
 
 @pytest.mark.asyncio
 async def test_policy_get_user_curfew_weekend(test_config):
-    """Test get_user_curfew for weekend."""
+    """Test get_user_curfew for a weekend day."""
     config, config_path = test_config
     policy = Policy(config_path)
 
-    curfew = policy.get_user_curfew("test_full_settings", is_weekend=True)
+    curfew = policy.get_user_curfew("test_full_settings", 5)  # Saturday
 
     # Should return a dict with start and end
     assert curfew is not None
@@ -219,8 +219,8 @@ async def test_policy_get_user_curfew_different_periods(test_config):
     policy = Policy(config_path)
 
     # test_full_settings has different weekday and weekend curfews
-    curfew_weekday = policy.get_user_curfew("test_full_settings", is_weekend=False)
-    curfew_weekend = policy.get_user_curfew("test_full_settings", is_weekend=True)
+    curfew_weekday = policy.get_user_curfew("test_full_settings", 0)  # Monday
+    curfew_weekend = policy.get_user_curfew("test_full_settings", 5)  # Saturday
 
     # Both should have values
     assert curfew_weekday is not None
@@ -228,6 +228,8 @@ async def test_policy_get_user_curfew_different_periods(test_config):
     # They should have start and end times
     assert "start" in curfew_weekday
     assert "start" in curfew_weekend
+    # The weekday and weekend windows differ
+    assert curfew_weekday != curfew_weekend
 
 
 @pytest.mark.asyncio

--- a/guardian_daemon/tests/test_sessions.py
+++ b/guardian_daemon/tests/test_sessions.py
@@ -107,17 +107,44 @@ async def test_check_curfew(test_config, mock_dbus, user_manager):
         "23:00", "%H:%M"
     ).time()  # After allowed hours (10:00-22:00)
 
-    # Test weekday during allowed hours
+    # Test weekday during allowed hours (Monday)
     assert (
-        await session_tracker.check_curfew(test_user, weekday_time, is_weekend=False)
-        is True
+        await session_tracker.check_curfew(test_user, weekday_time, weekday=0) is True
     )
 
-    # Test weekend after allowed hours
+    # Test weekend after allowed hours (Saturday)
     assert (
-        await session_tracker.check_curfew(test_user, weekend_time, is_weekend=True)
-        is False
+        await session_tracker.check_curfew(test_user, weekend_time, weekday=5) is False
     )
+
+
+@pytest.mark.asyncio
+async def test_check_curfew_overnight(test_config, mock_dbus, user_manager):
+    """An overnight allowed window (22:00-06:00) wraps past midnight."""
+    config, config_path = test_config
+    mock_bus, mock_logind = mock_dbus
+
+    policy = Policy(config_path)
+    storage = Storage(config["db_path"])
+    session_tracker = SessionTracker(policy, storage, user_manager)
+
+    test_user = "test_full_settings"
+    # Override the weekday window with an overnight one.
+    policy.data["users"][test_user]["curfew"]["weekdays"] = "22:00-06:00"
+
+    late_evening = datetime.strptime("23:30", "%H:%M").time()  # inside window
+    early_morning = datetime.strptime("05:00", "%H:%M").time()  # inside window
+    midday = datetime.strptime("12:00", "%H:%M").time()  # outside window
+
+    # Both sides of midnight are inside the allowed window -> login allowed.
+    assert (
+        await session_tracker.check_curfew(test_user, late_evening, weekday=0) is True
+    )
+    assert (
+        await session_tracker.check_curfew(test_user, early_morning, weekday=0) is True
+    )
+    # Midday is outside the overnight window -> login denied.
+    assert await session_tracker.check_curfew(test_user, midday, weekday=0) is False
 
 
 @pytest.mark.asyncio

--- a/guardian_daemon/tests/test_sessions.py
+++ b/guardian_daemon/tests/test_sessions.py
@@ -129,8 +129,11 @@ async def test_check_curfew_overnight(test_config, mock_dbus, user_manager):
     session_tracker = SessionTracker(policy, storage, user_manager)
 
     test_user = "test_full_settings"
-    # Override the weekday window with an overnight one.
-    policy.data["users"][test_user]["curfew"]["weekdays"] = "22:00-06:00"
+    # Override the weekday window with an overnight one. The effective curfew is
+    # resolved from stored settings, so write the override through storage.
+    settings = policy.storage.get_user_settings(test_user)
+    settings["curfew"]["weekdays"] = "22:00-06:00"
+    policy.storage.set_user_settings(test_user, settings)
 
     late_evening = datetime.strptime("23:30", "%H:%M").time()  # inside window
     early_morning = datetime.strptime("05:00", "%H:%M").time()  # inside window
@@ -145,6 +148,32 @@ async def test_check_curfew_overnight(test_config, mock_dbus, user_manager):
     )
     # Midday is outside the overnight window -> login denied.
     assert await session_tracker.check_curfew(test_user, midday, weekday=0) is False
+
+
+@pytest.mark.asyncio
+async def test_check_curfew_uses_default_for_user_without_explicit_curfew(
+    test_config, mock_dbus, user_manager
+):
+    """A user with no explicit curfew inherits the default curfew.
+
+    PAM enforces the default curfew for such a user (via _generate_rules), so
+    the session-level check must agree instead of always allowing.
+    """
+    config, config_path = test_config
+    mock_bus, mock_logind = mock_dbus
+
+    policy = Policy(config_path)
+    storage = Storage(config["db_path"])
+    session_tracker = SessionTracker(policy, storage, user_manager)
+
+    # test_minimal has only a quota; its curfew comes entirely from the
+    # defaults (weekdays 08:00-20:00).
+    test_user = "test_minimal"
+    inside = datetime.strptime("14:00", "%H:%M").time()
+    after = datetime.strptime("22:00", "%H:%M").time()
+
+    assert await session_tracker.check_curfew(test_user, inside, weekday=0) is True
+    assert await session_tracker.check_curfew(test_user, after, weekday=0) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The real curfew enforcement runs through PAM (`pam_time.so`) and is correct (incl. the overnight fix in #4). This PR fixes the **secondary Python-level curfew API** (`Policy.get_user_curfew()` and its consumers `sessions.check_curfew()` / `user_manager._is_user_in_curfew()`), which had drifted from what PAM actually enforces in three ways. Each one was masked, so the unit tests stayed green while the behaviour was wrong — "green tests, broken reality".

## Bug 1 — incompatible schema

There were **two `curfew` schemas** for the same config key:

- **Schema A (canonical)** — config (`default-config.yaml`), IPC write-validation (`ipc.py`), CLI, docs and PAM rule generation (`_generate_rules()`): keys `weekdays`/`saturday`/`sunday`/`all`, value `"HH:MM-HH:MM"` (the **allowed** window).
- **Schema B (phantom)** — only `get_user_curfew()` + its consumers: keys `weekday`/`weekend`, value `{"start", "end"}`.

Since the supported write path only ever produces Schema A, `get_user_curfew()` returned `None` on every real config, leaving both consumers inert (`check_curfew` always allowed; `_is_user_in_curfew` always `False`) and the `in_curfew=` log meaningless. The naming of `_is_user_in_curfew()` was also silently **inverted**.

**Fix:** read the canonical schema, keyed by the actual weekday (Mon=0..Sun=6, so Saturday and Sunday are distinguished). New shared, overnight-aware helpers `parse_hhmm()` + `is_within_curfew_window()` (half-open `[start, end)`, wraps midnight) used by both consumers. `_is_user_in_curfew()` now reports the **blocked** period (the complement of the allowed window).

## Bug 2 — default curfew ignored

`get_user_curfew()` read only the **explicit per-user** curfew, while `_generate_rules()` falls back to (and per-day merges) the **default** curfew. So a user relying on the default curfew was restricted by `pam_time` but reported as "no curfew" by the checks (which also short-circuited on the explicit-only `has_curfew()`).

**Fix:** new `policy.get_effective_curfew()` is the single source of truth — the user's settings merged over the defaults, exactly what `_generate_rules()` resolves. `_generate_rules()` is routed through it too, so the Python checks and the PAM rules **can no longer drift**. The consumers no longer gate on `has_curfew()`.

## Verification

- Daemon unit: **264 passed** (incl. new overnight + default-curfew regression tests)
- L3 PAM (`-m pam`): **11 passed** · L2 D-Bus (`-m dbus`): **9 passed**
- Lint gate (ruff / black / isort): **clean**

## Out of scope (noted)

`has_curfew()` / `get_monitored_users()` deliberately keep their explicit-per-user semantics, so the daemon's *monitored set* (which users are actively tracked/locked) is unchanged here. Whether a default-only-curfew, quota-exempt user should be in the monitored set is a separate question.

https://claude.ai/code/session_01GsUUGN8yWqX8tPkHoQQgu2