### PR TITLE
feat(daemon): treat default-curfew users as monitored

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -124,7 +124,9 @@ both sides of midnight.
   short-circuited on the explicit-only `has_curfew()`). Both now resolve the
   *effective* curfew through a single shared `policy.get_effective_curfew()` --
   the very helper `_generate_rules()` uses -- so the Python checks and the PAM
-  rules can no longer drift.
+  rules can no longer drift. `has_curfew()` (and therefore `get_monitored_users()`)
+  now reports the effective curfew too, so a user who relies on the default
+  curfew is correctly treated as having one and is monitored.
 - `storage.py` resolved the Alembic `script_location` relative to the process
   CWD, so DB migrations failed whenever the daemon/tests were launched from any
   directory other than `guardian_daemon/`. Now resolved against the daemon dir.

--- a/guardian_daemon/guardian_daemon/policy.py
+++ b/guardian_daemon/guardian_daemon/policy.py
@@ -100,9 +100,14 @@ class Policy:
         return False
 
     def has_curfew(self, username: str) -> bool:
-        """Check if a user has curfew settings."""
-        user_settings = self.data.get("users", {}).get(username, {})
-        return "curfew" in user_settings
+        """Check whether a user is subject to a curfew.
+
+        Reflects the *effective* curfew -- the user's own settings or the
+        inherited defaults -- matching what ``_generate_rules`` enforces via
+        ``pam_time``. A user that relies on the default curfew is therefore
+        reported as having one (and is consequently monitored).
+        """
+        return self.get_effective_curfew(username) is not None
 
     def get_user_quota(self, username: str) -> tuple[int, int]:
         """Get daily and weekly quota for a user."""
@@ -187,7 +192,8 @@ class Policy:
             # Check if user is explicitly marked as not monitored
             if not settings.get("monitored", True):  # Default is True if not specified
                 continue
-            # Include user if they have quota or curfew settings
+            # Monitor the user if they are subject to a quota or a curfew
+            # (own or inherited from the defaults).
             if self.has_quota(username) or self.has_curfew(username):
                 result.append(username)
         return result

--- a/guardian_daemon/tests/test_policy.py
+++ b/guardian_daemon/tests/test_policy.py
@@ -107,14 +107,16 @@ def test_policy_has_quota(test_config):
 
 
 def test_policy_has_curfew(test_config):
-    """Test checking if user has curfew settings."""
+    """Test checking if a user is subject to a curfew (own or default)."""
     config, config_path = test_config
     policy = Policy(config_path)
 
     assert policy.has_curfew("test_full_settings") is True
     assert policy.has_curfew("test_weekday_curfew") is True
-    assert policy.has_curfew("test_minimal") is False
-    assert policy.has_curfew("test_quota_only") is False
+    # No explicit curfew, but the default curfew applies (and PAM enforces it),
+    # so these users are subject to a curfew too.
+    assert policy.has_curfew("test_minimal") is True
+    assert policy.has_curfew("test_quota_only") is True
     assert policy.has_curfew("nonexistent") is False
 
 
@@ -126,15 +128,16 @@ def test_policy_get_monitored_users(test_config):
     users = policy.get_monitored_users()
     assert isinstance(users, list)
 
-    # Check for users that should be monitored
+    # Check for users that should be monitored. test_quota_exempt has no quota
+    # and no explicit curfew, but inherits the default curfew -> monitored.
     assert "test_full_settings" in users
     assert "test_quota_only" in users
     assert "test_minimal" in users
     assert "test_weekday_curfew" in users
+    assert "test_quota_exempt" in users
 
-    # Check for users that should not be monitored
-    assert "test_quota_exempt" not in users
+    # Explicitly opted out -> never monitored.
     assert "test_unmonitored" not in users
 
     # Verify total number of monitored users
-    assert len(users) == 4  # Number of test users that should be monitored
+    assert len(users) == 5  # All test users except the opted-out one

--- a/guardian_daemon/tests/test_policy_extended.py
+++ b/guardian_daemon/tests/test_policy_extended.py
@@ -91,13 +91,14 @@ async def test_policy_has_curfew_true(test_config):
 
 
 @pytest.mark.asyncio
-async def test_policy_has_curfew_false(test_config):
-    """Test has_curfew returns False when user has no curfew."""
+async def test_policy_has_curfew_inherits_default(test_config):
+    """has_curfew is True when a user inherits the default curfew."""
     config, config_path = test_config
     policy = Policy(config_path)
 
-    # test_quota_only has no curfew settings
-    assert policy.has_curfew("test_quota_only") is False
+    # test_quota_only has no explicit curfew but inherits the default one,
+    # which PAM enforces -- so it counts as having a curfew.
+    assert policy.has_curfew("test_quota_only") is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

A user who relies on the **default** curfew is restricted by `pam_time` (via `_generate_rules()`), but `Policy.has_curfew()` reported only an *explicit per-user* curfew. As a result such users were excluded from `get_monitored_users()`.

`has_curfew()` now reflects the **effective** curfew through the shared `get_effective_curfew()` helper, so a user who inherits the default curfew is reported as having one — and is therefore monitored. Only users explicitly opted out (`monitored: false`) remain unmonitored.

This is the follow-up flagged as "out of scope" in #5; the curfew schema/effective-resolution fixes it builds on are already on `main`.

## Why

It closes the last of the explicit-vs-effective curfew inconsistencies: `has_curfew()` / `get_monitored_users()` now agree with what PAM actually enforces, using the same single source of truth (`get_effective_curfew()`) as the rule generation and the curfew checks.

## Verification

- Daemon unit: **264 passed** (updated `test_policy_has_curfew`, `test_policy_get_monitored_users`; the former `has_curfew_false` test is now an `inherits_default` test — the false branch stays covered by the non-existent-user test)
- Lint gate (ruff / black / isort): **clean**
- PAM / D-Bus paths untouched (only `has_curfew` / `get_monitored_users` changed)

https://claude.ai/code/session_01GsUUGN8yWqX8tPkHoQQgu2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsUUGN8yWqX8tPkHoQQgu2)_